### PR TITLE
ignore /node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules


### PR DESCRIPTION
Since the JavaScript solutions were moved to their own repo in
https://github.com/careercup/CtCI-6th-Edition/commit/193f5975e58dd133b184f743f64089a760b62dc0 and https://github.com/careercup/CtCI-6th-Edition/commit/5ec5b2028123244fc9c831f71a812aa3e4c80f65, the `.gitignore` entry for `/node_modules` belongs in this repo.