### PR TITLE
(fix) Store correct new minimum

### DIFF
--- a/chapter03/3.2 - Stack Min/stackMin.js
+++ b/chapter03/3.2 - Stack Min/stackMin.js
@@ -18,7 +18,8 @@ stackMin.prototype.push = function(value) {
 stackMin.prototype.pop = function() {
   var answer = this.stack.pop();
   if (answer === this.currMin) {
-    this.currMin = this.minStack.pop();
+    this.minStack.pop();
+    this.currMin = this.minStack.peek();
   }
   return answer;
 };


### PR DESCRIPTION
It looks like the current code is storing the minimum that's being popped off, instead of the minimum from the remaining elements.