### PR TITLE
refactor: Remove unnecessary second argument in conditional statement

### DIFF
--- a/chapter01/1.1 - Is Unique/isUnique.js
+++ b/chapter01/1.1 - Is Unique/isUnique.js
@@ -26,7 +26,7 @@ const everyCharUnique = (str, indexOffset = 'a'.charCodeAt()) => {
 function everyCharUnique(str) {
   let obj = {};
   for (let i = 0; i < str.length; i++) {
-    if (obj[str[i]] && obj[str[i]] >= 1) {
+    if (obj[str[i]]) {
       return false;
     } else {
       obj[str[i]] = 1;

--- a/chapter01/1.3 - URLify/urlify-4.js
+++ b/chapter01/1.3 - URLify/urlify-4.js
@@ -1,0 +1,3 @@
+const URLify = (str) => {
+  return str.trim().replaceAll(' ', '%20');
+};

--- a/chapter01/1.3 - URLify/urlify-4.js
+++ b/chapter01/1.3 - URLify/urlify-4.js
@@ -1,3 +1,0 @@
-const URLify = (str) => {
-  return str.trim().replaceAll(' ', '%20');
-};


### PR DESCRIPTION
This commit refactors the code by removing the unnecessary second argument in the conditional statement. The condition "if (obj[str[i]] && obj[str[i]] >= 1)" has been simplified to "if (obj[str[i]])" for improved readability and code conciseness. This change helps to streamline the logic and remove unnecessary complexity from the codebase.